### PR TITLE
partially fix issue #14

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6784,7 +6784,7 @@
           "dev": true,
           "requires": {
             "underscore": "~1.7.0",
-            "underscore.string": "~2.4.0"
+            "underscore.string": ">=3.3.5"
           }
         }
       }


### PR DESCRIPTION
Fixed issue #14: two vulnerabilities in : 
1 - `underscore.string` : by update the version to 3.3.5.
2 - `remarkable 1.7.1` : issue remains unfixed since not patched by remarkable developers yet.